### PR TITLE
Fix deprecated use of guide=FALSE in R-basics.Rmd

### DIFF
--- a/R/R-basics.Rmd
+++ b/R/R-basics.Rmd
@@ -95,7 +95,7 @@ murders |> mutate(murder_rate = total/population*10^5,
   scale_y_continuous(breaks = NULL) +
   labs(x = "", y = "") +
   theme(panel.background = element_blank()) + 
-  scale_fill_brewer(guide=FALSE) +
+  scale_fill_brewer(guide="none") +
   theme_minimal()
 rm(fifty_states)
 ```


### PR DESCRIPTION
Current code produces the following console warning
```
Warning message:
The `guide` argument in `scale_*()` cannot be `FALSE`. This was deprecated in
ggplot2 3.3.4.
ℹ Please use "none" instead.
```
and this message is also displayed in the [Markdown book](http://rafalab.dfci.harvard.edu/dsbook/getting-started.html#rstudio) (pictured)

<img width="905" alt="Screenshot 2023-08-23 at 12 02 02 AM" src="https://github.com/pete-murphy/dsbook/assets/26548438/529cd3c3-f5e7-408b-8c32-68ebb71c72d3">
